### PR TITLE
Dockerfile improvements and automatic Github Actions builds

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -33,10 +33,3 @@ jobs:
           platforms: linux/amd64
           tags: public-pool:amd64
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
-      - 
-        name: Test-run image
-        run: |
-          docker run --rm public-pool:amd64 &
-          PID=$!
-          sleep 60
-          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on

--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -1,0 +1,42 @@
+name: "Test build of image when Dockerfile is changed"
+
+on:
+  push:
+    branches-ignore:
+    - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rebuild-container:
+    name: "Build image with cache"
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+        with:
+          platforms: linux/arm64
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - 
+        name: Checkout repository
+        uses: actions/checkout@v4
+      - 
+        name: Build image
+        id: docker_build_amd64
+        uses: docker/build-push-action@v5.1.0
+        with:
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: public-pool:amd64
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
+      - 
+        name: Test-run image
+        run: |
+          docker run --rm public-pool:amd64 &
+          PID=$!
+          sleep 60
+          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -21,12 +21,12 @@ jobs:
         with:
           push: false
           load: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/bitcoind:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/public-pool:latest
       - 
         name: Run Trivy vulnerability scanner against "latest" image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ secrets.DOCKER_USERNAME }}/bitcoind:latest'
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/public-pool:latest'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -1,0 +1,38 @@
+name: Build and scan container for vulnerabilities with Trivy
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '22 14 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and scan images
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout code
+        uses: actions/checkout@v4
+      - 
+        name: Build image from Dockerfile
+        uses: docker/build-push-action@v5.1.0
+        with:
+          push: false
+          load: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/bitcoind:latest
+      - 
+        name: Run Trivy vulnerability scanner against "latest" image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/bitcoind:latest'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+      - 
+        name: Upload "latest" Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -27,8 +27,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/public-pool:latest'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
       - 

--- a/.github/workflows/update-base-image.yml
+++ b/.github/workflows/update-base-image.yml
@@ -1,0 +1,61 @@
+name: "Update image and push to Github Packages and Docker Hub weekly"
+
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Run every Monday at noon.
+  workflow_dispatch:
+
+jobs:
+  rebuild-container:
+    name: "Rebuild Container with the latest base image"
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Prepare outputs
+        id: prep
+        run: |
+          echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+        with:
+          platforms: linux/arm64
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - 
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v3.0.0 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - 
+        name: Checkout repository
+        uses: actions/checkout@v4
+      - 
+        name: Get short SHA
+        id: get_short_sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - 
+        name: Build and push to Docker Hub and GitHub Packages Docker Registry
+        id: docker_build
+        uses: docker/build-push-action@v5.1.0
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/public-pool:latest
+            ghcr.io/${{ github.repository_owner }}/public-pool:${{ steps.get_short_sha.outputs.sha_short }}
+            ${{ secrets.DOCKER_USERNAME }}/public-pool:latest
+            ${{ secrets.DOCKER_USERNAME }}/public-pool:${{ steps.get_short_sha.outputs.sha_short }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -52,7 +52,7 @@ jobs:
           push: false
           load: true
           platforms: linux/amd64
-          tags: bitcoind:amd64
+          tags: public-pool:amd64
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
           cache-to: type=inline
       - 

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -1,0 +1,82 @@
+name: "Update image when Dockerfile is changed"
+
+on:
+  push:
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  rebuild-container:
+    name: "Rebuild Container with the latest base image"
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Prepare outputs
+        id: prep
+        run: |
+          echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+        with:
+          platforms: linux/arm64
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      - 
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v3.0.0 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - 
+        name: Checkout repository
+        uses: actions/checkout@v4
+      - 
+        name: Get short SHA
+        id: get_short_sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - 
+        name: Build image
+        id: docker_build_amd64
+        uses: docker/build-push-action@v5.1.0
+        with:
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: bitcoind:amd64
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
+          cache-to: type=inline
+      - 
+        name: Test-run image
+        run: |
+          docker run --rm public-pool:amd64 &
+          PID=$!
+          sleep 60
+          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on
+      - 
+        name: Build and push to Docker Hub and GitHub Packages Docker Registry
+        uses: docker/build-push-action@v5.1.0
+        id: docker_build_push
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/public-pool:latest
+            ghcr.io/${{ github.repository_owner }}/public-pool:${{ steps.get_short_sha.outputs.sha_short }}
+            ${{ secrets.DOCKER_USERNAME }}/public-pool:latest
+            ${{ secrets.DOCKER_USERNAME }}/public-pool:${{ steps.get_short_sha.outputs.sha_short }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
+          cache-to: type=inline

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -56,13 +56,6 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
           cache-to: type=inline
       - 
-        name: Test-run image
-        run: |
-          docker run --rm public-pool:amd64 &
-          PID=$!
-          sleep 60
-          kill -SIGINT $PID # this will return a non-zero exit code if the container dies early on
-      - 
         name: Build and push to Docker Hub and GitHub Packages Docker Registry
         uses: docker/build-push-action@v5.1.0
         id: docker_build_push

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -45,17 +45,6 @@ jobs:
         id: get_short_sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - 
-        name: Build image
-        id: docker_build_amd64
-        uses: docker/build-push-action@v5.1.0
-        with:
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: public-pool:amd64
-          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/public-pool:latest
-          cache-to: type=inline
-      - 
         name: Build and push to Docker Hub and GitHub Packages Docker Registry
         uses: docker/build-push-action@v5.1.0
         id: docker_build_push

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Docker build environment #
 ############################
 
-FROM node:18.16.1-bookworm AS build
+FROM node:18.16.1-bookworm-slim AS build
 
 WORKDIR /build
 
@@ -15,7 +15,7 @@ RUN npm run build
 # Docker final environment #
 ############################
 
-FROM node:18.16.1-bookworm
+FROM node:18.16.1-bookworm-slim
 
 EXPOSE 3333
 EXPOSE 3334

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     && apt-get upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python3 \
+        build-essential \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@
 
 FROM node:18.16.1-bookworm-slim AS build
 
+# Upgrade all packages and install dependencies
+RUN apt-get update \
+    && apt-get upgrade -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3 \
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 WORKDIR /build
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /build
 
 COPY . .
 
-RUN npm i
-RUN npm run build
+# Build Public Pool using NPM
+RUN npm i && npm run build
 
 ############################
 # Docker final environment #
@@ -17,12 +17,12 @@ RUN npm run build
 
 FROM node:18.16.1-bookworm-slim
 
-EXPOSE 3333
-EXPOSE 3334
-EXPOSE 8332
+# Expose ports for Stratum and Bitcoin RPC
+EXPOSE 3333 3334 8332
 
 WORKDIR /public-pool
 
+# Copy built binaries into the final image
 COPY --from=build /build .
 #COPY .env.example .env
 


### PR DESCRIPTION
This improves the Dockerfile slightly while adding automatic builds via Github Actions to allow you to easily distribute pre-built images.

If that is not something you want, please let me know and I will close this PR and maintain images on my own!

If you do want that, you will need to setup a Docker Hub account (if you wish) or just rely on Github Container Registry. If you want to use Docker Hub, simply create an account, create a Personal Access Token, and add it to the Action Secrets in your repo with the variables `DOCKER_USERNAME` and `DOCKER_PASSWORD`.

Once added, whenever you push to main/master Github will automatically build and push under the `latest` tag and a tag made of the short SHA of the latest commit (i.e. [here](https://hub.docker.com/repository/docker/sethforprivacy/public-pool/general)).

If no changes are made, it will also automatically rebuild and push the images weekly to keep the base image up to date with security patches etc.