### PR TITLE
stratum: set_difficulty should always be a notification

### DIFF
--- a/src/models/StratumV1Client.spec.ts
+++ b/src/models/StratumV1Client.spec.ts
@@ -202,7 +202,7 @@ describe('StratumV1Client', () => {
         expect(socket.on).toHaveBeenCalled();
         socketEmitter(Buffer.from(MockRecording1.MINING_SUGGEST_DIFFICULTY));
         await new Promise((r) => setTimeout(r, 1));
-        expect(socket.write).toHaveBeenCalledWith(`{"id":4,"method":"mining.set_difficulty","params":[512]}\n`, expect.any(Function));
+        expect(socket.write).toHaveBeenCalledWith(`{"id":null,"method":"mining.set_difficulty","params":[512]}\n`, expect.any(Function));
     });
 
     it('should set difficulty', async () => {

--- a/src/models/stratum-messages/SuggestDifficultyMessage.ts
+++ b/src/models/stratum-messages/SuggestDifficultyMessage.ts
@@ -31,7 +31,7 @@ export class SuggestDifficulty extends StratumBaseMessage {
 
     public response(difficulty: number) {
         return {
-            id: this.id,
+            id: null,
             method: eResponseMethod.SET_DIFFICULTY,
             params: [difficulty]
         }


### PR DESCRIPTION
the spec doesn't specify explicitely if set_difficulty should be replyed to client after he sent a [suggest_difficulty](https://en.bitcoin.it/wiki/Stratum_mining_protocol#mining.suggest_difficulty), that's OK if public-pool does it, but it should not use the same ID because [set_difficulty](https://braiins.com/stratum-v1/docs) is only specified as a notification.

ESP-Miner does not care about the type of message (notification with id:null or response with id from the request).

But other stratum implementation like the [SRI](https://github.com/stratum-mining/stratum) does check that and does not accept set_difficulty as a reponse only as a notification.