### PR TITLE
Add option to conect to Bitcoin RPC with cookie file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ BITCOIN_RPC_PASSWORD=
 BITCOIN_RPC_PORT=8332
 BITCOIN_RPC_TIMEOUT=10000
 
+# You can use this instead of BITCOIN_RPC_USER and BITCOIN_RPC_PASSWORD
+BITCOIN_RPC_COOKIEFILE=
+
 # Enable in bitcoin.conf with
 # zmqpubrawblock=tcp://*:3000
 # BITCOIN_ZMQ_HOST="tcp://192.168.1.100:3000"

--- a/src/services/bitcoin-rpc.service.ts
+++ b/src/services/bitcoin-rpc.service.ts
@@ -7,6 +7,7 @@ import * as zmq from 'zeromq';
 
 import { IBlockTemplate } from '../models/bitcoin-rpc/IBlockTemplate';
 import { IMiningInfo } from '../models/bitcoin-rpc/IMiningInfo';
+import * as fs from 'node:fs';
 
 @Injectable()
 export class BitcoinRpcService implements OnModuleInit {
@@ -24,10 +25,19 @@ export class BitcoinRpcService implements OnModuleInit {
 
     async onModuleInit() {
         const url = this.configService.get('BITCOIN_RPC_URL');
-        const user = this.configService.get('BITCOIN_RPC_USER');
-        const pass = this.configService.get('BITCOIN_RPC_PASSWORD');
+        let user = this.configService.get('BITCOIN_RPC_USER');
+        let pass = this.configService.get('BITCOIN_RPC_PASSWORD');
         const port = parseInt(this.configService.get('BITCOIN_RPC_PORT'));
         const timeout = parseInt(this.configService.get('BITCOIN_RPC_TIMEOUT'));
+
+        const cookiefile = this.configService.get('BITCOIN_RPC_COOKIEFILE')
+
+        if (cookiefile != undefined && cookiefile != '') {
+            const cookie = fs.readFileSync(cookiefile).toString().split(':')
+
+            user = cookie[0]
+            pass = cookie[1]
+        }
 
         this.client = new RPCClient({ url, port, timeout, user, pass });
 


### PR DESCRIPTION
Solves #15.

Tested running public-pool locally. If the cookie path does not exist or the cookie is not readable public-pool will throw an exception and abort on startup. If `BITCOIN_RPC_COOKIEFILE` is blank or not defined it is ignored.