### PR TITLE
Improve client message handling for cgminer

### DIFF
--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -7,6 +7,7 @@ import * as crypto from 'crypto';
 import { Socket } from 'net';
 import { firstValueFrom, Subscription } from 'rxjs';
 import { clearInterval } from 'timers';
+import { createInterface } from 'readline';
 
 import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
 import { BlocksService } from '../ORM/blocks/blocks.service';
@@ -64,19 +65,19 @@ export class StratumV1Client {
         private readonly addressSettingsService: AddressSettingsService
     ) {
 
-        this.socket.on('data', (data: Buffer) => {
-            data.toString()
-                .split('\n')
-                .filter(m => m.length > 0)
-                .forEach(async (m) => {
-                    try {
-                        await this.handleMessage(m);
-                    } catch (e) {
-                        await this.socket.end();
-                        console.error(e);
-                    }
-                })
-        });
+        const rl = createInterface({
+            input: this.socket
+        })
+
+        rl.on("line", async (line) => {
+            try {
+                await this.handleMessage(line);
+            } catch (e) {
+                await this.socket.end();
+                console.error(e);
+            }
+        })
+        rl.on('error', async (error: Error) => { });
 
 
     }


### PR DESCRIPTION
Having encountered #45, observed that cgminer sometimes sends JSON-RPC messages (specifically `mining.submit`) across several TCP segments, therefore implicitly relying on the `\n` at the end of the last segment to denote end-of message.

Public-Pool currently requires all segments to be fully contained JSON-RPC messages – therefore, if JSON parsing of any individual segment fails, then the message is lost (especially bad if a valid block solution 🤞) and the client connection is reset (bad for hashrate and tracking/statistics).

This change uses `readline` to only attempt JSON-RPC message parsing once the newline character is received, if necessary concatenating several TCP segments.