### PR TITLE
fix: handle null block templates due to RPC errors

### DIFF
--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -51,6 +51,9 @@ export class StratumV1JobsService {
                 }))
             }),
             map(({ blockTemplate, interval }) => {
+                if (blockTemplate == null) {
+                    return null;
+                }
 
                 let clearJobs = false;
                 if (this.lastIntervalCount === interval) {


### PR DESCRIPTION
If there are Bitcoin RPC errors e.g. RPC timeouts, then return the null block template. The null value will then be checked to return null when building a mining job, which is already filtered later in `stratum-v1-jobs.service.ts` via: `filter(next => next != null)`.

Removing the exception being thrown better handles the situation when there are RPC errors, since the exception was otherwise bubbling up to the mining job observer, thus causing an issue where no more miner jobs were being sent if the RPC connection was resolved.