### PR TITLE
switch to old useragent method

### DIFF
--- a/src/models/stratum-messages/SubscriptionMessage.ts
+++ b/src/models/stratum-messages/SubscriptionMessage.ts
@@ -41,7 +41,7 @@ export class SubscriptionMessage extends StratumBaseMessage {
 
     public static refineUserAgent(userAgent: string): string {
         // return userAgent;
-        userAgent = userAgent.split(' ')[0].split('/')[0].split('V')[0].split('-')[0];
+        userAgent = userAgent.split(' ')[0].split('/')[0].split('V')[0];
 
         if (userAgent.includes('bosminer') || userAgent.includes('bOS')) {
             userAgent = 'Braiins OS';


### PR DESCRIPTION
Braiins OS Miners are not anymore identified correctly, they only show up by their firmware year version.

![publicpool_wronguseragent](https://github.com/user-attachments/assets/b2815d76-fbea-4408-a45d-a503fd7fb415)

two users with braiins on our pool show the same bahvior. 