### PR TITLE
POSTGRES: Use `timestamptz` instead of `timestamp`

### DIFF
--- a/src/ORM/client/client.entity.ts
+++ b/src/ORM/client/client.entity.ts
@@ -26,7 +26,7 @@ export class ClientEntity extends TrackedEntity {
     userAgent: string;
 
 
-    @Column({ type: 'timestamp' })
+    @Column({ type: 'timestamptz' })
     startTime: Date;
 
     @Column({ type: 'decimal', default: 0 })

--- a/src/ORM/utils/TrackedEntity.entity.ts
+++ b/src/ORM/utils/TrackedEntity.entity.ts
@@ -1,12 +1,12 @@
 import { CreateDateColumn, DeleteDateColumn, UpdateDateColumn } from 'typeorm';
 
 export abstract class TrackedEntity {
-    @DeleteDateColumn({ nullable: true, type: 'timestamp' })
+    @DeleteDateColumn({ nullable: true, type: 'timestamptz' })
     public deletedAt?: Date;
 
-    @CreateDateColumn({ type: 'timestamp' })
+    @CreateDateColumn({ type: 'timestamptz' })
     public createdAt?: Date
 
-    @UpdateDateColumn({ type: 'timestamp' })
+    @UpdateDateColumn({ type: 'timestamptz' })
     public updatedAt?: Date
 }


### PR DESCRIPTION
Uses `timestamptz` instead of `timestamp` in the postgres entities so that date comparisons are correct through out the application. `timestamp` saves without a timezone-- It was saving the correct UTC time but without a timezone-- so any comparisons to server time yielded incorrect values. 

For example this fixed the hashrate recording and dead-client removal (because the time comparisons to save hashrates/shares never saved because of a negative difference in time during the if comparisons) etc. 

I've verified this change causes no side-effects or breakages in the server side application on the `postgres` branch. I believe `timestamptz` was the original intention not `timestamp`. 

I also should mention this fixed the offset that was also displaying on the public-pool-ui where database times where being displayed to the client. 
