### PR TITLE
Fix incorrect default POOL_IDENTIFIER value in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,5 @@ DEV_FEE_ADDRESS=
 NETWORK=mainnet
 
 API_SECURE=false
-# Default is "public-pool", you can change it to any string it will be removed if it will make the block or coinbase script too big
-POOL_IDENTIFIER="public-pool"
+# Default is "Public-Pool", you can change it to any string it will be removed if it will make the block or coinbase script too big
+POOL_IDENTIFIER="Public-Pool"


### PR DESCRIPTION
In `.env.example` the `POOL_IDENTIFIER` value is set as `"public-pool"` and it's documented that this is the default value.

The default value is actually `"Public-Pool"`.

https://github.com/benjamin-wilson/public-pool/blob/fda3f21b7189f95e40cafb24967202d973362711/src/models/MiningJob.ts#L47

The current example value will also not match the mempool.space matching logic for Public Pool which checks for the strings `"Public-Pool"` and `"Public Pool on Umbrel"`.

https://github.com/mempool/mining-pools/blob/40394e9fae2c7b321b82a767cbc616522efaa58a/pools-v2.json#L1733-L1742

This PR sets the example value to `"Public-Pool"` so the documentation re default value is correct and any blocks mined with the example config will be associated with Public Pool on mempool.space.