### PR TITLE
Update block template refresh logic and make interval configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ NETWORK=mainnet
 API_SECURE=false
 # Default is "Public-Pool", you can change it to any string it will be removed if it will make the block or coinbase script too big
 POOL_IDENTIFIER="Public-Pool"
+
+# Optional block template refresh interval (ms)
+#BLOCK_TEMPLATE_INTERVAL=30000

--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -38,11 +38,14 @@ export class StratumV1JobsService {
     // offset the interval so that all the cluster processes don't try and refresh at the same time.
     private delay = process.env.NODE_APP_INSTANCE == null ? 0 : parseInt(process.env.NODE_APP_INSTANCE) * 5000;
 
+    private block_template_interval: number =
+      parseInt(process.env.BLOCK_TEMPLATE_INTERVAL) || 60000;
+
     constructor(
         private readonly bitcoinRpcService: BitcoinRpcService
     ) {
 
-        this.newMiningJob$ = combineLatest([this.bitcoinRpcService.newBlock$, interval(60000).pipe(delay(this.delay), startWith(-1))]).pipe(
+        this.newMiningJob$ = combineLatest([this.bitcoinRpcService.newBlock$, interval(this.block_template_interval).pipe(delay(this.delay), startWith(-1))]).pipe(
             switchMap(([miningInfo, interval]) => {
                 return from(this.bitcoinRpcService.getBlockTemplate(miningInfo.blocks)).pipe(map((blockTemplate) => {
                     return {


### PR DESCRIPTION
This PR introduces  `BLOCK_TEMPLATE_INTERVAL` as an optional environment variable to allow configuration of the block template refresh interval.

 Updated the `.env.example` file and the `StratumV1JobsService` to support this change, defaulting to 60 seconds if not specified.