### PR TITLE
Set session difficulty via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ NETWORK=mainnet
 API_SECURE=false
 # Default is "Public-Pool", you can change it to any string it will be removed if it will make the block or coinbase script too big
 POOL_IDENTIFIER="Public-Pool"
+
+# Optional session difficulty (used as initial share diff)
+SESSION_DIFFICULTY=30000

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -42,7 +42,8 @@ export class StratumV1Client {
     private statistics: StratumV1ClientStatistics;
     private stratumInitialized = false;
     private usedSuggestedDifficulty = false;
-    private sessionDifficulty: number = 16384;
+    private sessionDifficulty: number =
+      parseInt(process.env.SESSION_DIFFICULTY) || 16384;
 
     private entity: ClientEntity;
     private creatingEntity: Promise<void>;


### PR DESCRIPTION
This PR allows configuring the initial session difficulty using the `SESSION_DIFFICULTY` environment variable. 

Updated `.env.example` to include an optional entry for this setting. Default remains 16384 if the variable is not set or invalid.