### PR TITLE
Update Nest Schedule to v4.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nestjs/config": "^2.3.2",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-fastify": "^9.4.2",
-        "@nestjs/schedule": "^3.0.1",
+        "@nestjs/schedule": "^4.1.2",
         "@nestjs/typeorm": "^10.0.0",
         "axios": "^1.4.0",
         "big.js": "^6.2.1",
@@ -1870,25 +1870,30 @@
       }
     },
     "node_modules/@nestjs/schedule": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.1.tgz",
-      "integrity": "sha512-4CAFu4rE/QPYnz/icRg3GiuLmY1bXopG8bWTJ9d7bXzaHBaPKIjGvZ20wsK8P+MncrVCkmK0iYhQrNj0cwX9+A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.1.2.tgz",
+      "integrity": "sha512-hCTQ1lNjIA5EHxeu8VvQu2Ed2DBLS1GSC6uKPYlBiQe6LL9a7zfE9iVSK+zuK8E2odsApteEBmfAQchc8Hx0Gg==",
+      "license": "MIT",
       "dependencies": {
-        "cron": "2.3.1",
-        "uuid": "9.0.0"
+        "cron": "3.2.1",
+        "uuid": "11.0.3"
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "reflect-metadata": "^0.1.12"
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@nestjs/schedule/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -2363,10 +2368,10 @@
       "dev": true
     },
     "node_modules/@types/luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -4334,11 +4339,13 @@
       "devOptional": true
     },
     "node_modules/cron": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-2.3.1.tgz",
-      "integrity": "sha512-1eRRlIT0UfIqauwbG9pkg3J6CX9A6My2ytJWqAXoK0T9oJnUZTzGBNPxao0zjodIbPgf8UQWjE62BMb9eVllSQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.2.1.tgz",
+      "integrity": "sha512-w2n5l49GMmmkBFEsH9FIDhjZ1n1QgTMOCMGuQtOXs5veNiosZmso6bQGuqOJSYAXXrG84WQFVneNk+Yt0Ua9iw==",
+      "license": "MIT",
       "dependencies": {
-        "luxon": "^3.2.1"
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
       }
     },
     "node_modules/cross-env": {
@@ -7838,9 +7845,10 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -13053,18 +13061,18 @@
       }
     },
     "@nestjs/schedule": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.1.tgz",
-      "integrity": "sha512-4CAFu4rE/QPYnz/icRg3GiuLmY1bXopG8bWTJ9d7bXzaHBaPKIjGvZ20wsK8P+MncrVCkmK0iYhQrNj0cwX9+A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.1.2.tgz",
+      "integrity": "sha512-hCTQ1lNjIA5EHxeu8VvQu2Ed2DBLS1GSC6uKPYlBiQe6LL9a7zfE9iVSK+zuK8E2odsApteEBmfAQchc8Hx0Gg==",
       "requires": {
-        "cron": "2.3.1",
-        "uuid": "9.0.0"
+        "cron": "3.2.1",
+        "uuid": "11.0.3"
       },
       "dependencies": {
         "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+          "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg=="
         }
       }
     },
@@ -13460,10 +13468,9 @@
       "dev": true
     },
     "@types/luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -14997,11 +15004,12 @@
       "devOptional": true
     },
     "cron": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-2.3.1.tgz",
-      "integrity": "sha512-1eRRlIT0UfIqauwbG9pkg3J6CX9A6My2ytJWqAXoK0T9oJnUZTzGBNPxao0zjodIbPgf8UQWjE62BMb9eVllSQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.2.1.tgz",
+      "integrity": "sha512-w2n5l49GMmmkBFEsH9FIDhjZ1n1QgTMOCMGuQtOXs5veNiosZmso6bQGuqOJSYAXXrG84WQFVneNk+Yt0Ua9iw==",
       "requires": {
-        "luxon": "^3.2.1"
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
       }
     },
     "cross-env": {
@@ -17623,9 +17631,9 @@
       }
     },
     "luxon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
-      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
     },
     "macos-release": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@nestjs/config": "^2.3.2",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-fastify": "^9.4.2",
-    "@nestjs/schedule": "^3.0.1",
+    "@nestjs/schedule": "^4.1.2",
     "@nestjs/typeorm": "^10.0.0",
     "axios": "^1.4.0",
     "big.js": "^6.2.1",


### PR DESCRIPTION
Currently `nest start` contains a deprecation warning. To fix this, the `next schedule` package is updated to version 4.1.2.

```
> public-pool@0.0.1 start
> nest start

(node:3095) [DEP0056] DeprecationWarning: The `util.isString` API is deprecated.  Please use `typeof arg === "string"` instead.
    at Interval (/public-pool/node_modules/@nestjs/schedule/dist/decorators/interval.decorator.js:12:57)
 ```