### PR TITLE
Subscribe to ZMQ hashblock instead of rawblock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ BITCOIN_RPC_TIMEOUT=10000
 BITCOIN_RPC_COOKIEFILE=
 
 # Enable in bitcoin.conf with
-# zmqpubrawblock=tcp://*:3000
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:3000"
+# zmqpubhashblock=tcp://*:28334
+# BITCOIN_ZMQ_HOST="tcp://127.0.0.1:28334"
 
 API_PORT=3334
 STRATUM_PORT=3333

--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ BITCOIN_RPC_TIMEOUT=10000
 BITCOIN_RPC_COOKIEFILE=
 
 # Enable in bitcoin.conf with
-# zmqpubhashblock=tcp://*:28334
-# BITCOIN_ZMQ_HOST="tcp://127.0.0.1:28334"
+# zmqpubhashblock=tcp://*:28332
+# BITCOIN_ZMQ_HOST="tcp://127.0.0.1:28332"
 
 API_PORT=3334
 STRATUM_PORT=3333

--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ The docker-compose binds to `127.0.0.1` by default. To expose the Stratum servic
 +      - "3334"
 ```
 
-**note**: To successfully connect to the bitcoin RPC you will need to add
+**note**: To successfully connect to Bitcoin Core, configure your `bitcoin.conf`:
 
-```
+```ini
+# Allow RPC access from the container/host network:
 rpcallowip=172.16.0.0/12
-```
 
-to your bitcoin.conf.
+# Publish real-time block notifications via ZeroMQ (required for instant block detection):
+zmqpubhashblock=tcp://0.0.0.0:28334
+```

--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ The docker-compose binds to `127.0.0.1` by default. To expose the Stratum servic
 rpcallowip=172.16.0.0/12
 
 # Publish real-time block notifications via ZeroMQ (required for instant block detection):
-zmqpubhashblock=tcp://0.0.0.0:28334
+zmqpubhashblock=tcp://0.0.0.0:28332
 ```

--- a/full-setup/public-pool-mainnet.env
+++ b/full-setup/public-pool-mainnet.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=8332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubrawblock=tcp://*:3000
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:3000"
+# zmqpubhashblock=tcp://*:28334
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
 
 API_PORT=3334
 STRATUM_PORT=3333

--- a/full-setup/public-pool-mainnet.env
+++ b/full-setup/public-pool-mainnet.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=8332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubhashblock=tcp://*:28334
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
+# zmqpubhashblock=tcp://*:28332
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28332"
 
 API_PORT=3334
 STRATUM_PORT=3333

--- a/full-setup/public-pool-regtest.env
+++ b/full-setup/public-pool-regtest.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=28332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubrawblock=tcp://*:3000
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:3000"
+# zmqpubhashblock=tcp://*:28334
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
 
 API_PORT=23334
 STRATUM_PORT=23333

--- a/full-setup/public-pool-regtest.env
+++ b/full-setup/public-pool-regtest.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=28332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubhashblock=tcp://*:28334
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
+# zmqpubhashblock=tcp://*:28332
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28332"
 
 API_PORT=23334
 STRATUM_PORT=23333

--- a/full-setup/public-pool-testnet.env
+++ b/full-setup/public-pool-testnet.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=18332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubrawblock=tcp://*:3000
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:3000"
+# zmqpubhashblock=tcp://*:28334
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
 
 API_PORT=13334
 STRATUM_PORT=13333

--- a/full-setup/public-pool-testnet.env
+++ b/full-setup/public-pool-testnet.env
@@ -5,8 +5,8 @@ BITCOIN_RPC_PORT=18332
 BITCOIN_RPC_TIMEOUT=10000
 
 # Enable in bitcoin.conf with
-# zmqpubhashblock=tcp://*:28334
-# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28334"
+# zmqpubhashblock=tcp://*:28332
+# BITCOIN_ZMQ_HOST="tcp://192.168.1.100:28332"
 
 API_PORT=13334
 STRATUM_PORT=13333

--- a/src/services/bitcoin-rpc.service.ts
+++ b/src/services/bitcoin-rpc.service.ts
@@ -70,7 +70,6 @@ export class BitcoinRpcService implements OnModuleInit {
             });
 
             sock.connect(this.configService.get('BITCOIN_ZMQ_HOST'));
-            sock.subscribe('rawblock');
             sock.subscribe('hashblock');
             // Don't await this, otherwise it will block the rest of the program
             this.listenForNewBlocks(sock);

--- a/src/services/bitcoin-rpc.service.ts
+++ b/src/services/bitcoin-rpc.service.ts
@@ -71,6 +71,7 @@ export class BitcoinRpcService implements OnModuleInit {
 
             sock.connect(this.configService.get('BITCOIN_ZMQ_HOST'));
             sock.subscribe('rawblock');
+            sock.subscribe('hashblock');
             // Don't await this, otherwise it will block the rest of the program
             this.listenForNewBlocks(sock);
             await this.pollMiningInfo();
@@ -82,7 +83,7 @@ export class BitcoinRpcService implements OnModuleInit {
 
     private async listenForNewBlocks(sock: zmq.Subscriber) {
         for await (const [topic, msg] of sock) {
-            console.log("New Block");
+            console.log(`New Block detected via ZMQ (${topic.toString()}): ${msg ? msg.toString('hex') : ''}`);
             await this.pollMiningInfo();
         }
     }

--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -36,6 +36,7 @@ export class StratumV1JobsService {
     // offset the interval so that all the cluster processes don't try and refresh at the same time.
     private delay = process.env.NODE_APP_INSTANCE == null ? 0 : parseInt(process.env.NODE_APP_INSTANCE) * 5000;
     private lastBlockHeight = 0;
+    private lastPrevHash: string;
     private lastWorkSignature: string;
 
     constructor(
@@ -59,11 +60,16 @@ export class StratumV1JobsService {
 
                 let clearJobs = false;
                 const currentBlockHeight = miningInfo.blocks;
+                const isNewHeight = this.lastBlockHeight === 0 || this.lastBlockHeight !== currentBlockHeight;
+                const isNewPrevHash = this.lastPrevHash != null && this.lastPrevHash !== blockTemplate.previousblockhash;
 
-                if (this.lastBlockHeight == 0 || this.lastBlockHeight != currentBlockHeight) {
+                if (isNewHeight || isNewPrevHash) {
                     clearJobs = true;
                     this.lastBlockHeight = currentBlockHeight;
-                    console.log('new block');
+                    this.lastPrevHash = blockTemplate.previousblockhash;
+                    console.log(`new block: height=${blockTemplate.height} (chain tip=${currentBlockHeight}), prevHash=${blockTemplate.previousblockhash}`);
+                } else if (this.lastPrevHash == null) {
+                    this.lastPrevHash = blockTemplate.previousblockhash;
                 }
 
                 const currentTime = Math.floor(new Date().getTime() / 1000);


### PR DESCRIPTION
The ZMQ `hashblock` topic is only used to receive a new block notification, however, this is a fairly heavy message at several MBs. Switching to `hashblock` does the same, but with a 45 byte message.

It also fixes a bug where `cleanJobs` was not set to true if the `previousblockhash` changed but the height didn't, e.g. on a block re-org or a competing block.