### PR TITLE
Block propagation optimizations

### DIFF
--- a/src/models/MiningJob.spec.ts
+++ b/src/models/MiningJob.spec.ts
@@ -89,6 +89,7 @@ describe('MiningJob', () => {
                     networkDifficulty: 0,
                     height: 0,
                     clearJobs: false,
+                    blockWeight: block.weight()
                 }
             } as IJobTemplate;
         });
@@ -149,6 +150,7 @@ describe('MiningJob', () => {
         it('should use the POOL_IDENTIFIER if it doesn\'t make the script size too big with identifier abcabc', () => {
 
             jobTemplate.block.transactions = []; // remove transactions because we only want to test the script size
+            jobTemplate.blockData.blockWeight = jobTemplate.block.weight();
             const expectedMiningIdentifier = 'A'.repeat(84); // 84 chars fits after reserving 12 bytes for extranonce space
             configService.get = jest.fn((key: string) => {
                 switch (key) {
@@ -168,6 +170,7 @@ describe('MiningJob', () => {
         it('should remove pool identifier if script is too big with identifier', () => {
             const expectedMiningIdentifier = '';
             jobTemplate.block.transactions = []; // remove transactions because we only want to test the script size
+            jobTemplate.blockData.blockWeight = jobTemplate.block.weight();
             configService.get = jest.fn((key: string) => {
                 switch (key) {
                     case 'POOL_IDENTIFIER': return 'A'.repeat(85);
@@ -181,6 +184,15 @@ describe('MiningJob', () => {
             const miningIdentifier = extractPoolIdentifierFromScript(response.params[2]);
             expect(console.warn).toBeCalledWith('Pool identifier is too long, removing the pool identifier');
             expect(miningIdentifier).toBe(expectedMiningIdentifier);
+        });
+
+        it('should trust blockWeight from jobTemplate.blockData without calling block.weight()', () => {
+            const weightSpy = jest.spyOn(jobTemplate.block, 'weight');
+            jobTemplate.blockData.blockWeight = 12345;
+
+            new MiningJob(configService, bitcoinjs.networks.testnet, '1', payoutInformation, jobTemplate);
+
+            expect(weightSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/src/models/MiningJob.spec.ts
+++ b/src/models/MiningJob.spec.ts
@@ -79,9 +79,17 @@ describe('MiningJob', () => {
                 block.transactions.push(bitcoinjs.Transaction.fromHex("010000000001017405e391018c5e9dc79f324f9607c9c46d21b02f66dabaa870b4add871d6379f01000000171600148d7a0a3461e3891723e5fdf8129caa0075060cffffffffff01fcf60200000000001600148d7a0a3461e3891723e5fdf8129caa0075060cff0248304502210088025cffdaf69d310c6fed11832edd9c19b6a912c132262701ad0e6133227d9202207d73bbf777abd2aeae995d684e6bb1a048c5ac722e16de48bdd35643df7decf001210283409659355b6d1cc3c32decd5d561abaac86c37a353b52895a5e6c196d6f44800000000"));
             }
 
+            const segwitMagicBits = Buffer.from('aa21a9ed', 'hex');
+            const witnessCommitScript = bitcoinjs.script.compile([
+                bitcoinjs.opcodes.OP_RETURN,
+                Buffer.concat([segwitMagicBits, block.witnessCommit])
+            ]);
+
             jobTemplate = {
                 block: block,
                 merkle_branch: [],
+                merkleBranchBuffers: [],
+                witnessCommitScript,
                 blockData: {
                     id: '1',
                     creation: Date.now(),
@@ -89,9 +97,13 @@ describe('MiningJob', () => {
                     networkDifficulty: 0,
                     height: 0,
                     clearJobs: false,
-                    blockWeight: block.weight()
+                    blockWeight: block.weight(),
+                    prevHashHex: '0000000000000000000000000000000000000000000000000000000000000000',
+                    versionHex: '20000000',
+                    bitsHex: '1d00ffff',
+                    timestampHex: '66df21a0'
                 }
-            } as IJobTemplate;
+            };
         });
 
         afterEach(() => {
@@ -193,6 +205,36 @@ describe('MiningJob', () => {
             new MiningJob(configService, bitcoinjs.networks.testnet, '1', payoutInformation, jobTemplate);
 
             expect(weightSpy).not.toHaveBeenCalled();
+        });
+
+        it('should reuse pre-computed merkleBranchBuffers and witnessCommitScript from jobTemplate', () => {
+            const testBranchBuffer = Buffer.from('aa'.repeat(32), 'hex');
+            jobTemplate.merkleBranchBuffers = [testBranchBuffer];
+            const testWitnessScript = Buffer.from('6a24aa21a9ed' + 'bb'.repeat(32), 'hex');
+            jobTemplate.witnessCommitScript = testWitnessScript;
+
+            const miningJob = new MiningJob(configService, bitcoinjs.networks.testnet, '1', payoutInformation, jobTemplate);
+
+            const calculateMerkleSpy = jest.spyOn(miningJob as any, 'calculateMerkleRootHash');
+            miningJob.buildHeaderBuffer(jobTemplate, 0, 1234, '00', '00', 123456);
+
+            expect(calculateMerkleSpy).toHaveBeenCalledWith(expect.any(Buffer), jobTemplate.merkleBranchBuffers);
+            expect((miningJob as any).coinbaseTransaction.outs[1].script).toEqual(testWitnessScript);
+        });
+
+        it('should reuse pre-computed hex strings in response() without recomputing', () => {
+            jobTemplate.blockData.prevHashHex = 'custom-prev-hash-hex';
+            jobTemplate.blockData.versionHex = 'custom-version-hex';
+            jobTemplate.blockData.bitsHex = 'custom-bits-hex';
+            jobTemplate.blockData.timestampHex = 'custom-time-hex';
+
+            const miningJob = new MiningJob(configService, bitcoinjs.networks.testnet, '1', payoutInformation, jobTemplate);
+            const response = JSON.parse(miningJob.response(jobTemplate));
+
+            expect(response.params[1]).toBe('custom-prev-hash-hex');
+            expect(response.params[5]).toBe('custom-version-hex');
+            expect(response.params[6]).toBe('custom-bits-hex');
+            expect(response.params[7]).toBe('custom-time-hex');
         });
     });
 

--- a/src/models/MiningJob.ts
+++ b/src/models/MiningJob.ts
@@ -74,7 +74,7 @@ export class MiningJob {
         this.coinbaseTransaction.addOutput(bitcoinjs.script.compile([bitcoinjs.opcodes.OP_RETURN, Buffer.concat([segwitMagicBits, jobTemplate.block.witnessCommit])]), 0);
 
         // Check if the pool identifier is too long
-        if ((this.coinbaseTransaction.weight() + jobTemplate.block.weight()) > MAX_BLOCK_WEIGHT) {
+        if ((this.coinbaseTransaction.weight() + jobTemplate.blockData.blockWeight) > MAX_BLOCK_WEIGHT) {
             console.warn('Block weight exceeds the maximum allowed weight, removing the pool identifier');
             let script = Buffer.concat([blockHeightLengthByte, blockHeightEncoded, padding]);
             this.coinbaseTransaction.ins[0].script = script;

--- a/src/models/MiningJob.ts
+++ b/src/models/MiningJob.ts
@@ -20,7 +20,6 @@ export class MiningJob {
     private coinbasePart2: string;
     private coinbasePart1Buffer: Buffer;
     private coinbasePart2Buffer: Buffer;
-    private merkleBranchBuffers: Buffer[];
 
     public jobTemplateId: string;
     public networkDifficulty: number;
@@ -36,18 +35,9 @@ export class MiningJob {
 
         this.creation = new Date().getTime();
         this.jobTemplateId = jobTemplate.blockData.id;
-        this.merkleBranchBuffers = jobTemplate.merkle_branch.map(branch => Buffer.from(branch, 'hex'));
 
         this.coinbaseTransaction = this.createCoinbaseTransaction(payoutInformation, jobTemplate.blockData.coinbasevalue);
 
-        //The commitment is recorded in a scriptPubKey of the coinbase transaction. It must be at least 38 bytes, with the first 6-byte of 0x6a24aa21a9ed, that is:
-        //     1-byte - OP_RETURN (0x6a)
-        //     1-byte - Push the following 36 bytes (0x24)
-        //     4-byte - Commitment header (0xaa21a9ed)
-        const segwitMagicBits = Buffer.from('aa21a9ed', 'hex');
-        //    32-byte - Commitment hash: Double-SHA256(witness root hash|witness reserved value)
-
-        //    39th byte onwards: Optional data with no consensus meaning
         // Initial pool identifier
         let poolIdentifier = configService.get('POOL_IDENTIFIER') || 'Public-Pool';
         let extra = Buffer.from(poolIdentifier);
@@ -71,7 +61,8 @@ export class MiningJob {
         }
 
         this.coinbaseTransaction.ins[0].script = script;
-        this.coinbaseTransaction.addOutput(bitcoinjs.script.compile([bitcoinjs.opcodes.OP_RETURN, Buffer.concat([segwitMagicBits, jobTemplate.block.witnessCommit])]), 0);
+        // Add pre-computed BIP 141 SegWit witness commitment output
+        this.coinbaseTransaction.addOutput(jobTemplate.witnessCommitScript, 0);
 
         // Check if the pool identifier is too long
         if ((this.coinbaseTransaction.weight() + jobTemplate.blockData.blockWeight) > MAX_BLOCK_WEIGHT) {
@@ -107,7 +98,7 @@ export class MiningJob {
             this.coinbasePart2Buffer,
         ]);
         const coinbaseHash = bitcoinjs.crypto.hash256(coinbaseBuffer);
-        const merkleRoot = this.calculateMerkleRootHash(coinbaseHash, this.merkleBranchBuffers);
+        const merkleRoot = this.calculateMerkleRootHash(coinbaseHash, jobTemplate.merkleBranchBuffers);
 
         let version = jobTemplate.block.version;
         if (versionMask !== undefined && versionMask != 0) {
@@ -147,7 +138,7 @@ export class MiningJob {
         testBlock.transactions[0].ins[0].script = Buffer.from(`${nonceScript.substring(0, nonceScript.length - (TOTAL_EXTRANONCE_SIZE_BYTES * 2))}${extraNonce}${extraNonce2}`, 'hex');
 
         //recompute the root since we updated the coinbase script with the nonces
-        testBlock.merkleRoot = this.calculateMerkleRootHash(testBlock.transactions[0].getHash(false), this.merkleBranchBuffers);
+        testBlock.merkleRoot = this.calculateMerkleRootHash(testBlock.transactions[0].getHash(false), jobTemplate.merkleBranchBuffers);
 
 
         testBlock.timestamp = timestamp;
@@ -233,33 +224,17 @@ export class MiningJob {
             method: eResponseMethod.MINING_NOTIFY,
             params: [
                 this.jobId,
-                this.swapEndianWords(jobTemplate.block.prevHash).toString('hex'),
+                jobTemplate.blockData.prevHashHex,
                 this.coinbasePart1,
                 this.coinbasePart2,
                 jobTemplate.merkle_branch,
-                jobTemplate.block.version.toString(16),
-                jobTemplate.block.bits.toString(16),
-                jobTemplate.block.timestamp.toString(16),
+                jobTemplate.blockData.versionHex,
+                jobTemplate.blockData.bitsHex,
+                jobTemplate.blockData.timestampHex,
                 jobTemplate.blockData.clearJobs
             ]
         };
 
         return JSON.stringify(job) + '\n';
     }
-
-
-    private swapEndianWords(buffer: Buffer): Buffer {
-        const swappedBuffer = Buffer.alloc(buffer.length);
-
-        for (let i = 0; i < buffer.length; i += 4) {
-            swappedBuffer[i] = buffer[i + 3];
-            swappedBuffer[i + 1] = buffer[i + 2];
-            swappedBuffer[i + 2] = buffer[i + 1];
-            swappedBuffer[i + 3] = buffer[i];
-        }
-
-        return swappedBuffer;
-    }
-
-
 }

--- a/src/models/MiningJob.ts
+++ b/src/models/MiningJob.ts
@@ -9,6 +9,8 @@ import { TOTAL_EXTRANONCE_SIZE_BYTES } from './stratum.constants';
 
 const MAX_BLOCK_WEIGHT = 4000000;
 const MAX_SCRIPT_SIZE = 100; //   https://github.com/bitcoin/bitcoin/blob/ffdc3d6060f6e65e69cf115a13b83e6eb4a0a0a8/src/consensus/tx_check.cpp#L49
+const DEFAULT_POOL_IDENTIFIER = 'Public-Pool';
+const DEFAULT_POOL_IDENTIFIER_BUFFER = Buffer.from(DEFAULT_POOL_IDENTIFIER);
 interface AddressObject {
     address: string;
     percent: number;
@@ -22,12 +24,11 @@ export class MiningJob {
     private coinbasePart2Buffer: Buffer;
 
     public jobTemplateId: string;
-    public networkDifficulty: number;
     public creation: number;
 
     constructor(
         configService: ConfigService,
-        private network: bitcoinjs.networks.Network,
+        network: bitcoinjs.networks.Network,
         public jobId: string,
         payoutInformation: AddressObject[],
         jobTemplate: IJobTemplate
@@ -36,11 +37,13 @@ export class MiningJob {
         this.creation = new Date().getTime();
         this.jobTemplateId = jobTemplate.blockData.id;
 
-        this.coinbaseTransaction = this.createCoinbaseTransaction(payoutInformation, jobTemplate.blockData.coinbasevalue);
+        this.coinbaseTransaction = this.createCoinbaseTransaction(payoutInformation, jobTemplate.blockData.coinbasevalue, network);
 
         // Initial pool identifier
-        let poolIdentifier = configService.get('POOL_IDENTIFIER') || 'Public-Pool';
-        let extra = Buffer.from(poolIdentifier);
+        const poolIdentifier = configService.get('POOL_IDENTIFIER') || DEFAULT_POOL_IDENTIFIER;
+        const extra = poolIdentifier === DEFAULT_POOL_IDENTIFIER
+            ? DEFAULT_POOL_IDENTIFIER_BUFFER
+            : Buffer.from(poolIdentifier);
 
         // Encode the block height
         // https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
@@ -163,7 +166,7 @@ export class MiningJob {
     }
 
 
-    private createCoinbaseTransaction(addresses: AddressObject[], reward: number): bitcoinjs.Transaction {
+    private createCoinbaseTransaction(addresses: AddressObject[], reward: number, network: bitcoinjs.networks.Network): bitcoinjs.Transaction {
         // Part 1
         const coinbaseTransaction = new bitcoinjs.Transaction();
 
@@ -179,7 +182,7 @@ export class MiningJob {
         addresses.forEach(recipientAddress => {
             const amount = Math.floor((recipientAddress.percent / 100) * reward);
             rewardBalance -= amount;
-            coinbaseTransaction.addOutput(this.getPaymentScript(recipientAddress.address), amount);
+            coinbaseTransaction.addOutput(this.getPaymentScript(recipientAddress.address, network), amount);
         })
 
         //Add any remaining sats from the Math.floor
@@ -193,23 +196,23 @@ export class MiningJob {
         return coinbaseTransaction;
     }
 
-    private getPaymentScript(address: string): Buffer {
+    private getPaymentScript(address: string, network: bitcoinjs.networks.Network): Buffer {
         const addressInfo = getAddressInfo(address);
         switch (addressInfo.type) {
             case AddressType.p2wpkh: {
-                return bitcoinjs.payments.p2wpkh({ address, network: this.network }).output;
+                return bitcoinjs.payments.p2wpkh({ address, network }).output;
             }
             case AddressType.p2pkh: {
-                return bitcoinjs.payments.p2pkh({ address, network: this.network }).output;
+                return bitcoinjs.payments.p2pkh({ address, network }).output;
             }
             case AddressType.p2sh: {
-                return bitcoinjs.payments.p2sh({ address, network: this.network }).output;
+                return bitcoinjs.payments.p2sh({ address, network }).output;
             }
             case AddressType.p2tr: {
-                return bitcoinjs.payments.p2tr({ address, network: this.network }).output;
+                return bitcoinjs.payments.p2tr({ address, network }).output;
             }
             case AddressType.p2wsh: {
-                return bitcoinjs.payments.p2wsh({ address, network: this.network }).output;
+                return bitcoinjs.payments.p2wsh({ address, network }).output;
             }
             default: {
                 return Buffer.alloc(0);

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -677,7 +677,11 @@ export class StratumV1Client {
                 block: Object.assign(new bitcoinjs.Block(), jobTemplate.block, {
                     timestamp: nextTimestamp
                 }),
-                blockData: { ...jobTemplate.blockData, clearJobs: true }
+                blockData: {
+                    ...jobTemplate.blockData,
+                    timestampHex: nextTimestamp.toString(16),
+                    clearJobs: true
+                }
             };
             await this.sendNewMiningJob(refreshedJobTemplate);
 

--- a/src/services/stratum-v1-jobs.service.spec.ts
+++ b/src/services/stratum-v1-jobs.service.spec.ts
@@ -1,3 +1,4 @@
+import * as bitcoinjs from 'bitcoinjs-lib';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 
 import { MockRecording1 } from '../../test/models/MockRecording1';
@@ -134,5 +135,16 @@ describe('StratumV1JobsService', () => {
 
         expect(service.getNextId()).toBe('2');
         expect(service.getJobById('1')).toEqual(expect.objectContaining({ jobId: '1' }));
+    });
+
+    it('should use pre-computed txids and default_witness_commitment without redundant hashing', async () => {
+        const calculateMerkleSpy = jest.spyOn(bitcoinjs.Block, 'calculateMerkleRoot');
+        const getHashSpy = jest.spyOn(bitcoinjs.Transaction.prototype, 'getHash');
+
+        const jobTemplate = await firstValueFrom(service.newMiningJob$);
+
+        expect(calculateMerkleSpy).not.toHaveBeenCalled();
+        expect(getHashSpy).toHaveBeenCalledTimes(1);
+        expect(jobTemplate.witnessCommitScript).toEqual(Buffer.from(MockRecording1.BLOCK_TEMPLATE.default_witness_commitment, 'hex'));
     });
 });

--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -95,6 +95,8 @@ export class StratumV1JobsService {
                     bits: parseInt(blockTemplate.bits, 16),
                     prevHash: this.convertToLittleEndian(blockTemplate.previousblockhash),
                     transactions: blockTemplate.transactions.map(t => bitcoinjs.Transaction.fromHex(t.data)),
+                    txids: blockTemplate.transactions.map(t => t.txid),
+                    defaultWitnessCommitment: blockTemplate.default_witness_commitment,
                     coinbasevalue: blockTemplate.coinbasevalue,
                     timestamp,
                     networkDifficulty: this.calculateNetworkDifficulty(parseInt(blockTemplate.bits, 16)),
@@ -103,7 +105,7 @@ export class StratumV1JobsService {
                 };
             }),
             filter(next => next != null),
-            map(({ version, bits, prevHash, transactions, timestamp, coinbasevalue, networkDifficulty, clearJobs, height }) => {
+            map(({ version, bits, prevHash, transactions, txids, defaultWitnessCommitment, timestamp, coinbasevalue, networkDifficulty, clearJobs, height }) => {
                 const block = new bitcoinjs.Block();
 
                 //create an empty coinbase tx
@@ -113,7 +115,10 @@ export class StratumV1JobsService {
                 tempCoinbaseTx.ins[0].witness = [Buffer.alloc(32, 0)];
                 transactions.unshift(tempCoinbaseTx);
 
-                const transactionBuffers = transactions.map(tx => tx.getHash(false));
+                const transactionBuffers = [
+                    tempCoinbaseTx.getHash(false),
+                    ...txids.map(txid => Buffer.from(txid, 'hex').reverse())
+                ];
 
                 const merkleTree = merkle(transactionBuffers, bitcoinjs.crypto.hash256);
                 const merkleBranches: Buffer[] = merkleProof(merkleTree, transactionBuffers[0]).filter(h => h != null);
@@ -129,19 +134,22 @@ export class StratumV1JobsService {
                 block.timestamp = timestamp;
 
                 block.transactions = transactions;
-                block.witnessCommit = bitcoinjs.Block.calculateMerkleRoot(transactions, true);
 
                 // The commitment is recorded in a scriptPubKey of the coinbase transaction. It must be at least 38 bytes, with the first 6-byte of 0x6a24aa21a9ed, that is:
                 //     1-byte - OP_RETURN (0x6a)
                 //     1-byte - Push the following 36 bytes (0x24)
                 //     4-byte - Commitment header (0xaa21a9ed)
-                const segwitMagicBits = Buffer.from('aa21a9ed', 'hex');
                 //    32-byte - Commitment hash: Double-SHA256(witness root hash|witness reserved value)
                 //    39th byte onwards: Optional data with no consensus meaning
-                const witnessCommitScript = bitcoinjs.script.compile([
-                    bitcoinjs.opcodes.OP_RETURN,
-                    Buffer.concat([segwitMagicBits, block.witnessCommit])
-                ]);
+                // BIP 145: Use pre-computed witness commitment from getblocktemplate if available
+                const witnessCommitScript = defaultWitnessCommitment
+                    ? Buffer.from(defaultWitnessCommitment, 'hex')
+                    : bitcoinjs.script.compile([
+                        bitcoinjs.opcodes.OP_RETURN,
+                        Buffer.concat([Buffer.from('aa21a9ed', 'hex'), bitcoinjs.Block.calculateMerkleRoot(transactions, true)])
+                    ]);
+
+                block.witnessCommit = witnessCommitScript.subarray(6, 38);
 
                 const id = this.getNextTemplateId();
                 this.latestJobTemplateId++;

--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -11,14 +11,20 @@ export interface IJobTemplate {
 
     block: bitcoinjs.Block;
     merkle_branch: string[];
+    merkleBranchBuffers: Buffer[];
+    witnessCommitScript: Buffer;
     blockData: {
-        id: string,
-        creation: number,
+        id: string;
+        creation: number;
         coinbasevalue: number;
         networkDifficulty: number;
         height: number;
         clearJobs: boolean;
         blockWeight: number;
+        prevHashHex: string;
+        versionHex: string;
+        bitsHex: string;
+        timestampHex: string;
     };
 }
 
@@ -114,7 +120,8 @@ export class StratumV1JobsService {
                 block.merkleRoot = merkleBranches.pop();
 
                 // remove the first (coinbase) and last (root) element from the branch
-                const merkle_branch = merkleBranches.slice(1, merkleBranches.length).map(b => b.toString('hex'))
+                const merkleBranchBuffers = merkleBranches.slice(1, merkleBranches.length);
+                const merkle_branch = merkleBranchBuffers.map(b => b.toString('hex'));
 
                 block.prevHash = prevHash;
                 block.version = version;
@@ -124,11 +131,25 @@ export class StratumV1JobsService {
                 block.transactions = transactions;
                 block.witnessCommit = bitcoinjs.Block.calculateMerkleRoot(transactions, true);
 
+                // The commitment is recorded in a scriptPubKey of the coinbase transaction. It must be at least 38 bytes, with the first 6-byte of 0x6a24aa21a9ed, that is:
+                //     1-byte - OP_RETURN (0x6a)
+                //     1-byte - Push the following 36 bytes (0x24)
+                //     4-byte - Commitment header (0xaa21a9ed)
+                const segwitMagicBits = Buffer.from('aa21a9ed', 'hex');
+                //    32-byte - Commitment hash: Double-SHA256(witness root hash|witness reserved value)
+                //    39th byte onwards: Optional data with no consensus meaning
+                const witnessCommitScript = bitcoinjs.script.compile([
+                    bitcoinjs.opcodes.OP_RETURN,
+                    Buffer.concat([segwitMagicBits, block.witnessCommit])
+                ]);
+
                 const id = this.getNextTemplateId();
                 this.latestJobTemplateId++;
                 return {
                     block,
                     merkle_branch,
+                    merkleBranchBuffers,
+                    witnessCommitScript,
                     blockData: {
                         id,
                         creation: new Date().getTime(),
@@ -136,7 +157,11 @@ export class StratumV1JobsService {
                         networkDifficulty,
                         height,
                         clearJobs,
-                        blockWeight: block.weight()
+                        blockWeight: block.weight(),
+                        prevHashHex: Buffer.from(block.prevHash).swap32().toString('hex'),
+                        versionHex: block.version.toString(16),
+                        bitsHex: block.bits.toString(16),
+                        timestampHex: block.timestamp.toString(16)
                     }
                 }
             }),

--- a/src/services/stratum-v1-jobs.service.ts
+++ b/src/services/stratum-v1-jobs.service.ts
@@ -18,6 +18,7 @@ export interface IJobTemplate {
         networkDifficulty: number;
         height: number;
         clearJobs: boolean;
+        blockWeight: number;
     };
 }
 
@@ -134,7 +135,8 @@ export class StratumV1JobsService {
                         coinbasevalue,
                         networkDifficulty,
                         height,
-                        clearJobs
+                        clearJobs,
+                        blockWeight: block.weight()
                     }
                 }
             }),


### PR DESCRIPTION
This PR has several performance optimisations for block propagation:

 * Caches result of `block.weight()`. This function loops over all transactions twice and was done for each connected client
 * Pre-compute several fields only once per template
 * Use native `Buffer.swap32()`
 * Use pre-computed `txids` and `default_witness_commitment` from `getblocktemplate` (BIP-145)
 * Eliminate per-miner allocations in MiningJob