### PR TITLE
Enable HTTP keep-alive on Bitcoin RPC client

### DIFF
--- a/src/services/bitcoin-rpc.service.spec.ts
+++ b/src/services/bitcoin-rpc.service.spec.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { BitcoinRpcService } from './bitcoin-rpc.service';
+
+describe('BitcoinRpcService', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('should configure axios with keepAlive agents on module init', async () => {
+        const axiosCreateSpy = jest.spyOn(axios, 'create').mockReturnValue({
+            post: jest.fn().mockResolvedValue({ data: { result: {} } })
+        } as any);
+
+        const configService = {
+            get: jest.fn((key: string) => {
+                switch (key) {
+                    case 'BITCOIN_RPC_URL': return 'http://127.0.0.1';
+                    case 'BITCOIN_RPC_USER': return 'user';
+                    case 'BITCOIN_RPC_PASSWORD': return 'pass';
+                    case 'BITCOIN_RPC_PORT': return '8332';
+                    case 'BITCOIN_RPC_TIMEOUT': return '10000';
+                    default: return null;
+                }
+            })
+        } as unknown as ConfigService;
+
+        const service = new BitcoinRpcService(configService, null as any);
+        await service.onModuleInit();
+
+        expect(axiosCreateSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                httpAgent: expect.objectContaining({ keepAlive: true }),
+                httpsAgent: expect.objectContaining({ keepAlive: true })
+            })
+        );
+        axiosCreateSpy.mockRestore();
+    });
+});

--- a/src/services/bitcoin-rpc.service.ts
+++ b/src/services/bitcoin-rpc.service.ts
@@ -2,6 +2,8 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
 import { BehaviorSubject, filter, shareReplay } from 'rxjs';
 import * as zmq from 'zeromq';
 
@@ -47,7 +49,9 @@ export class BitcoinRpcService implements OnModuleInit {
             auth: {
                 username: user,
                 password: pass
-            }
+            },
+            httpAgent: new http.Agent({ keepAlive: true }),
+            httpsAgent: new https.Agent({ keepAlive: true })
         });
 
         this.callRpc('getrpcinfo').then(() => {


### PR DESCRIPTION
Keeps the Bitcoin RPC client connection alive between RPC calls