### PR TITLE
chore: correct package.json license and document regtest network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ STRATUM_MAX_CONNECTIONS_PER_LISTENER=10000
 
 #optional
 DEV_FEE_ADDRESS=
-# mainnet | testnet
+# mainnet | testnet | regtest
 NETWORK=mainnet
 
 API_SECURE=false

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "public-pool",
   "version": "0.0.1",
-  "description": "",
+  "description": "A NestJS and TypeScript Bitcoin Stratum V1 solo mining server.",
   "author": "",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "GPL-3.0",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
Three lines across two files, independent of #164.

`package.json` says `"license": "UNLICENSED"`, which is npm's marker for proprietary, while `LICENSE.txt` is GPL-3.0 and GitHub detects GPL-3.0 for the repo.

The manifest field is what npm, dependency scanners and SBOM tooling read, so any license audit against this project today is told it is proprietary.

This does not decide between `GPL-3.0-only` and `GPL-3.0-or-later`: the repo doesn't state which is intended, so I used plain `GPL-3.0` to match GitHub's detection, and either explicit SPDX form is a one-word change if you prefer it.

The empty `description` is filled from the README's own description line; `author` and `version` are left alone as yours to set.

`.env.example` lists only `mainnet | testnet`, but `StratumV1Client.ts` accepts `regtest` and `full-setup/` ships `docker-compose-regtest.yml` for it, so the comment now lists all three.

Verified `package.json` still parses; no code changes.
