### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Public Pool
+
+Thanks for taking the time to contribute. Bug reports, fixes and features are all welcome.
+
+## Prerequisites
+
+- **Node.js `22.12.0` or newer** — enforced by the `engines` field in `package.json`
+- **A Bitcoin Core node** with RPC enabled and reachable from the pool
+
+If you do not run a node already, [`full-setup/`](full-setup/) contains Docker Compose stacks that start Bitcoin Core and Public Pool together for mainnet, testnet or regtest.
+
+## Getting set up
+
+```bash
+# fork the repository, then
+$ git clone https://github.com/<your-username>/public-pool.git
+$ cd public-pool
+$ npm install
+$ cp .env.example .env
+```
+
+Edit `.env` and point `BITCOIN_RPC_URL`, `BITCOIN_RPC_USER` and `BITCOIN_RPC_PASSWORD` at your node. See the Configuration section of the [README](README.md) for every available option.
+
+Then run the server in watch mode:
+
+```bash
+$ npm run start:dev
+```
+
+### Developing without mainnet
+
+Set `NETWORK=regtest` in `.env` and use the regtest stack in [`full-setup/`](full-setup/README.md). It lets you generate blocks on demand, so you can exercise the full submit-and-find path without waiting on real network difficulty.
+
+## Before opening a pull request
+
+```bash
+$ npm run lint     # eslint, applies --fix
+$ npm run format   # prettier
+$ npm run test     # jest
+```
+
+Please make sure the test suite passes. If you are changing Stratum message handling, mining job construction or difficulty calculation, add or update the matching `*.spec.ts` file — those areas already have unit tests and are the easiest places to introduce subtle breakage.
+
+## Code style
+
+Style is enforced by ESLint and Prettier, configured in [`.eslintrc.js`](.eslintrc.js) and [`.prettierrc`](.prettierrc):
+
+- Single quotes
+- Trailing commas everywhere
+- `@typescript-eslint/recommended`
+
+Run `npm run format` rather than adjusting formatting by hand.
+
+## Project layout
+
+```
+src/
+  app.controller.ts      Pool, network and info endpoints
+  controllers/           Client and external-share endpoints
+  models/                Stratum messages, mining jobs, client state
+  models/stratum-messages/  One class per Stratum V1 method
+  services/              Bitcoin RPC, Stratum server, notifications
+  ORM/                   TypeORM entities and services (SQLite)
+  utils/                 Difficulty helpers
+full-setup/              Bitcoin Core + Public Pool compose stacks
+```
+
+Unit tests live next to the code they cover as `*.spec.ts`.
+
+## Pull requests
+
+- Branch from `master` and open your pull request against `master`.
+- Keep changes focused. A small, single-purpose pull request is much easier to review than a broad one.
+- Describe what the change does and why. If it fixes an issue, reference it.
+- Note in the description if you have tested against mainnet, testnet or regtest.
+
+## Reporting bugs
+
+Open an [issue](https://github.com/benjamin-wilson/public-pool/issues) and include:
+
+- What you expected to happen, and what happened instead
+- Your `NETWORK` setting and Node.js version
+- The miner hardware and firmware you are connecting with, if relevant
+- Relevant log output, with RPC credentials and addresses redacted
+
+For security vulnerabilities, please do **not** open a public issue — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Public Pool constructs coinbase transactions, handles Bitcoin RPC credentials and accepts untrusted input from mining hardware over the network. A publicly disclosed flaw could be exploited against live pools before operators have a chance to update.
+
+Instead, report privately:
+
+- Use **GitHub private vulnerability reporting** — go to the [Security tab](https://github.com/benjamin-wilson/public-pool/security) and choose *Report a vulnerability*.
+- If that is unavailable, contact the maintainer directly rather than filing a public issue.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- The affected version or commit
+- The network you observed it on (mainnet, testnet or regtest)
+
+## Scope
+
+Issues that are especially relevant to this project:
+
+- Coinbase or merkle construction flaws that could misdirect a block reward
+- Stratum message parsing that can crash, hang or be used to exhaust server resources
+- Share validation bypasses, including submitting work that credits another address
+- Exposure of Bitcoin RPC credentials, cookie file contents, or the TLS key in `secrets/`
+- Authorization flaws allowing one address to read or affect another's workers
+
+The following are generally **not** vulnerabilities in this project:
+
+- Misconfiguration of your own Bitcoin node, such as an over-permissive `rpcallowip`
+- Exposing the Stratum or API port to the public internet without a firewall
+- Denial of service that requires privileged network position or physical access
+
+## Supported versions
+
+This project does not currently publish tagged releases. Security fixes are applied to the `master` branch, and operators are encouraged to track it.
+
+## Disclosure
+
+Please give a reasonable window to investigate and ship a fix before disclosing publicly. Reports will be acknowledged, and credit given if you would like it.
+
+## Hardening reminders for operators
+
+- **Replace the bundled TLS certificate before enabling `API_SECURE`.** `secrets/cert.pem` and `secrets/key.pem` are committed to this repository as a convenience default. It is a self-signed certificate for `127.0.0.1`, and **its private key is public**. Serving the API over HTTPS with it provides no confidentiality, because anyone can obtain the key and decrypt or impersonate the connection. Generate your own key pair for any deployment that is not purely local.
+- Keep the API port (`API_PORT`, default `3334`) bound to localhost or behind a reverse proxy unless you intend it to be public. The bundled `docker-compose.yml` binds to `127.0.0.1` by default.
+- Prefer `BITCOIN_RPC_COOKIEFILE` over storing an RPC password in `.env`.
+- Do not commit your `.env`. It is already covered by `.gitignore`.
+- Scope `rpcallowip` in `bitcoin.conf` as narrowly as your deployment allows.


### PR DESCRIPTION
Two new files, nothing existing touched, and independent of #164 and #165.

GitHub reports "No security policy detected" on the Security tab, and there is no contributing guidance for a project with 156 forks.

## CONTRIBUTING.md

Documented from what is already in the repo: the `>=22.12.0` engine requirement, setup via `npm install` and `cp .env.example .env`, the existing `lint` / `format` / `test` scripts, and the ESLint and Prettier rules already configured.

Also covers source layout, that unit tests live beside their code as `*.spec.ts`, and the regtest stack in `full-setup/` for exercising the full submit-and-find path without mainnet difficulty.

## SECURITY.md

Asks for private reporting with explicit scope — coinbase and merkle construction, Stratum parsing crashes, share validation bypasses, RPC credential exposure — and excludes operator misconfiguration such as an over-permissive `rpcallowip`.

It is worded to stay accurate whether or not private vulnerability reporting is enabled; turning it on is a checkbox under Settings → Security, or I can swap in a contact address.

## One thing worth a look

`secrets/cert.pem` and `secrets/key.pem` are committed as a convenience default, so the private key is public.

That is fine for local use and is what makes `API_SECURE=true` work out of the box, but an operator flipping it on a public host without replacing the pair gets TLS with no confidentiality and no signal that anything is wrong, and the cert is valid until 2033.

I documented it rather than changing anything; generating a pair at container start or refusing to boot with the bundled key felt out of scope for a docs PR.
